### PR TITLE
メンバーリストのUI

### DIFF
--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -21,7 +21,7 @@ const GroupMemberList = ({list, onRemove}) => (
       list.length !== 0 ? list.map((publicId, i) =>
         <Container data-test='groupmemberlist-member' key={i}>
           <PublicIDWrap>
-            {publicId}
+            確認用ID: {publicId}
           </PublicIDWrap>
           <button className='button is-danger' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
         </Container>

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -19,7 +19,7 @@ const GroupMemberList = ({list, onRemove}) => (
           <PublicIDWrap>
             {publicId}
           </PublicIDWrap>
-          <button className='button is-danger is-outlined' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
+          <button className='button is-danger' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
         </Container>
       ) : <span data-test='groupmemberlist-notfound'>一緒に応募する人はいません。</span>
     }

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -4,11 +4,12 @@ import { observer } from 'mobx-react'
 
 const PublicIDWrap = styled.span`
   width: 3rem;
-  display: inline-block;
 `
 
 const Container = styled.div`
   margin: 5px;
+  display: flex;
+  align-items: center;
 `
 
 const GroupMemberList = ({list, onRemove}) => (

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -7,16 +7,20 @@ const PublicIDWrap = styled.span`
   display: inline-block;
 `
 
+const Container = styled.div`
+  margin: 5px;
+`
+
 const GroupMemberList = ({list, onRemove}) => (
   <div>
     {
       list.length !== 0 ? list.map((publicId, i) =>
-        <div data-test='groupmemberlist-member' key={i}>
+        <Container data-test='groupmemberlist-member' key={i}>
           <PublicIDWrap>
             {publicId}
           </PublicIDWrap>
           <button className='button is-danger is-outlined' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
-        </div>
+        </Container>
       ) : <span data-test='groupmemberlist-notfound'>一緒に応募する人はいません。</span>
     }
   </div>

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 
 const PublicIDWrap = styled.span`
   width: 3rem;
+  font-size: 1rem;
 `
 
 const Container = styled.div`

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -6,6 +6,7 @@ const PublicIDWrap = styled.span`
   width: 3rem;
   font-size: 1rem;
   margin: 0 5px;
+  flex-grow: 3;
 `
 
 const Container = styled.div`

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react'
 const PublicIDWrap = styled.span`
   width: 3rem;
   font-size: 1rem;
+  margin: 0 5px;
 `
 
 const Container = styled.div`

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -7,7 +7,7 @@ const GroupMemberList = ({list, onRemove}) => (
       list.length !== 0 ? list.map((publicId, i) =>
         <div data-test='groupmemberlist-member' key={i}>
           {publicId}
-          <button data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>Remove</button>
+          <button data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>キャンセル</button>
         </div>
       ) : <span data-test='groupmemberlist-notfound'>一緒に応募する人はいません。</span>
     }

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 
 const PublicIDWrap = styled.span`
   width: 3rem;
+  display: inline-block;
 `
 
 const GroupMemberList = ({list, onRemove}) => (

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -1,13 +1,20 @@
 import React from 'react'
+import styled from 'styled-components'
 import { observer } from 'mobx-react'
+
+const PublicIDWrap = styled.span`
+  width: 3rem;
+`
 
 const GroupMemberList = ({list, onRemove}) => (
   <div>
     {
       list.length !== 0 ? list.map((publicId, i) =>
         <div data-test='groupmemberlist-member' key={i}>
-          {publicId}
-          <button data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>キャンセル</button>
+          <PublicIDWrap>
+            {publicId}
+          </PublicIDWrap>
+          <button className='button is-danger is-outlined' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
         </div>
       ) : <span data-test='groupmemberlist-notfound'>一緒に応募する人はいません。</span>
     }

--- a/src/component/GroupMemberList.js
+++ b/src/component/GroupMemberList.js
@@ -21,7 +21,7 @@ const GroupMemberList = ({list, onRemove}) => (
       list.length !== 0 ? list.map((publicId, i) =>
         <Container data-test='groupmemberlist-member' key={i}>
           <PublicIDWrap>
-            確認用ID: {publicId}
+            確認用ID: <b>{publicId}</b>
           </PublicIDWrap>
           <button className='button is-danger' data-test='groupmemberlist-remove' onClick={() => onRemove(i)}>削除</button>
         </Container>

--- a/src/component/__tests__/__snapshots__/GroupMemberList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/GroupMemberList.spec.js.snap
@@ -26,39 +26,57 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
-        <div
+        <styled.div
           data-test="groupmemberlist-member"
         >
-          public_id1
+          <styled.span>
+            確認用ID: 
+            <b>
+              public_id1
+            </b>
+          </styled.span>
           <button
+            className="button is-danger"
             data-test="groupmemberlist-remove"
             onClick={[Function]}
           >
-            Remove
+            削除
           </button>
-        </div>,
-        <div
+        </styled.div>,
+        <styled.div
           data-test="groupmemberlist-member"
         >
-          public_id2
+          <styled.span>
+            確認用ID: 
+            <b>
+              public_id2
+            </b>
+          </styled.span>
           <button
+            className="button is-danger"
             data-test="groupmemberlist-remove"
             onClick={[Function]}
           >
-            Remove
+            削除
           </button>
-        </div>,
-        <div
+        </styled.div>,
+        <styled.div
           data-test="groupmemberlist-member"
         >
-          public_id3
+          <styled.span>
+            確認用ID: 
+            <b>
+              public_id3
+            </b>
+          </styled.span>
           <button
+            className="button is-danger"
             data-test="groupmemberlist-remove"
             onClick={[Function]}
           >
-            Remove
+            削除
           </button>
-        </div>,
+        </styled.div>,
       ],
     },
     "ref": null,
@@ -66,107 +84,212 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": "0",
-        "nodeType": "host",
+        "nodeType": "class",
         "props": Object {
           "children": Array [
-            "public_id1",
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id1
+              </b>
+            </styled.span>,
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>,
           ],
           "data-test": "groupmemberlist-member",
         },
         "ref": null,
         "rendered": Array [
-          "public_id1",
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                "確認用ID: ",
+                <b>
+                  public_id1
+                </b>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "確認用ID: ",
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "public_id1",
+                },
+                "ref": null,
+                "rendered": "public_id1",
+                "type": "b",
+              },
+            ],
+            "type": [Function],
+          },
           Object {
             "instance": null,
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "Remove",
+              "children": "削除",
+              "className": "button is-danger",
               "data-test": "groupmemberlist-remove",
               "onClick": [Function],
             },
             "ref": null,
-            "rendered": "Remove",
+            "rendered": "削除",
             "type": "button",
           },
         ],
-        "type": "div",
+        "type": [Function],
       },
       Object {
         "instance": null,
         "key": "1",
-        "nodeType": "host",
+        "nodeType": "class",
         "props": Object {
           "children": Array [
-            "public_id2",
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id2
+              </b>
+            </styled.span>,
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>,
           ],
           "data-test": "groupmemberlist-member",
         },
         "ref": null,
         "rendered": Array [
-          "public_id2",
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                "確認用ID: ",
+                <b>
+                  public_id2
+                </b>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "確認用ID: ",
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "public_id2",
+                },
+                "ref": null,
+                "rendered": "public_id2",
+                "type": "b",
+              },
+            ],
+            "type": [Function],
+          },
           Object {
             "instance": null,
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "Remove",
+              "children": "削除",
+              "className": "button is-danger",
               "data-test": "groupmemberlist-remove",
               "onClick": [Function],
             },
             "ref": null,
-            "rendered": "Remove",
+            "rendered": "削除",
             "type": "button",
           },
         ],
-        "type": "div",
+        "type": [Function],
       },
       Object {
         "instance": null,
         "key": "2",
-        "nodeType": "host",
+        "nodeType": "class",
         "props": Object {
           "children": Array [
-            "public_id3",
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id3
+              </b>
+            </styled.span>,
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>,
           ],
           "data-test": "groupmemberlist-member",
         },
         "ref": null,
         "rendered": Array [
-          "public_id3",
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": Array [
+                "確認用ID: ",
+                <b>
+                  public_id3
+                </b>,
+              ],
+            },
+            "ref": null,
+            "rendered": Array [
+              "確認用ID: ",
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "public_id3",
+                },
+                "ref": null,
+                "rendered": "public_id3",
+                "type": "b",
+              },
+            ],
+            "type": [Function],
+          },
           Object {
             "instance": null,
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "Remove",
+              "children": "削除",
+              "className": "button is-danger",
               "data-test": "groupmemberlist-remove",
               "onClick": [Function],
             },
             "ref": null,
-            "rendered": "Remove",
+            "rendered": "削除",
             "type": "button",
           },
         ],
-        "type": "div",
+        "type": [Function],
       },
     ],
     "type": "div",
@@ -178,39 +301,57 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
-          <div
+          <styled.div
             data-test="groupmemberlist-member"
           >
-            public_id1
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id1
+              </b>
+            </styled.span>
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>
-          </div>,
-          <div
+          </styled.div>,
+          <styled.div
             data-test="groupmemberlist-member"
           >
-            public_id2
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id2
+              </b>
+            </styled.span>
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>
-          </div>,
-          <div
+          </styled.div>,
+          <styled.div
             data-test="groupmemberlist-member"
           >
-            public_id3
+            <styled.span>
+              確認用ID: 
+              <b>
+                public_id3
+              </b>
+            </styled.span>
             <button
+              className="button is-danger"
               data-test="groupmemberlist-remove"
               onClick={[Function]}
             >
-              Remove
+              削除
             </button>
-          </div>,
+          </styled.div>,
         ],
       },
       "ref": null,
@@ -218,107 +359,212 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": "0",
-          "nodeType": "host",
+          "nodeType": "class",
           "props": Object {
             "children": Array [
-              "public_id1",
+              <styled.span>
+                確認用ID: 
+                <b>
+                  public_id1
+                </b>
+              </styled.span>,
               <button
+                className="button is-danger"
                 data-test="groupmemberlist-remove"
                 onClick={[Function]}
               >
-                Remove
+                削除
               </button>,
             ],
             "data-test": "groupmemberlist-member",
           },
           "ref": null,
           "rendered": Array [
-            "public_id1",
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  "確認用ID: ",
+                  <b>
+                    public_id1
+                  </b>,
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "確認用ID: ",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "public_id1",
+                  },
+                  "ref": null,
+                  "rendered": "public_id1",
+                  "type": "b",
+                },
+              ],
+              "type": [Function],
+            },
             Object {
               "instance": null,
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "Remove",
+                "children": "削除",
+                "className": "button is-danger",
                 "data-test": "groupmemberlist-remove",
                 "onClick": [Function],
               },
               "ref": null,
-              "rendered": "Remove",
+              "rendered": "削除",
               "type": "button",
             },
           ],
-          "type": "div",
+          "type": [Function],
         },
         Object {
           "instance": null,
           "key": "1",
-          "nodeType": "host",
+          "nodeType": "class",
           "props": Object {
             "children": Array [
-              "public_id2",
+              <styled.span>
+                確認用ID: 
+                <b>
+                  public_id2
+                </b>
+              </styled.span>,
               <button
+                className="button is-danger"
                 data-test="groupmemberlist-remove"
                 onClick={[Function]}
               >
-                Remove
+                削除
               </button>,
             ],
             "data-test": "groupmemberlist-member",
           },
           "ref": null,
           "rendered": Array [
-            "public_id2",
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  "確認用ID: ",
+                  <b>
+                    public_id2
+                  </b>,
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "確認用ID: ",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "public_id2",
+                  },
+                  "ref": null,
+                  "rendered": "public_id2",
+                  "type": "b",
+                },
+              ],
+              "type": [Function],
+            },
             Object {
               "instance": null,
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "Remove",
+                "children": "削除",
+                "className": "button is-danger",
                 "data-test": "groupmemberlist-remove",
                 "onClick": [Function],
               },
               "ref": null,
-              "rendered": "Remove",
+              "rendered": "削除",
               "type": "button",
             },
           ],
-          "type": "div",
+          "type": [Function],
         },
         Object {
           "instance": null,
           "key": "2",
-          "nodeType": "host",
+          "nodeType": "class",
           "props": Object {
             "children": Array [
-              "public_id3",
+              <styled.span>
+                確認用ID: 
+                <b>
+                  public_id3
+                </b>
+              </styled.span>,
               <button
+                className="button is-danger"
                 data-test="groupmemberlist-remove"
                 onClick={[Function]}
               >
-                Remove
+                削除
               </button>,
             ],
             "data-test": "groupmemberlist-member",
           },
           "ref": null,
           "rendered": Array [
-            "public_id3",
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": Array [
+                  "確認用ID: ",
+                  <b>
+                    public_id3
+                  </b>,
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                "確認用ID: ",
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "public_id3",
+                  },
+                  "ref": null,
+                  "rendered": "public_id3",
+                  "type": "b",
+                },
+              ],
+              "type": [Function],
+            },
             Object {
               "instance": null,
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "Remove",
+                "children": "削除",
+                "className": "button is-danger",
                 "data-test": "groupmemberlist-remove",
                 "onClick": [Function],
               },
               "ref": null,
-              "rendered": "Remove",
+              "rendered": "削除",
               "type": "button",
             },
           ],
-          "type": "div",
+          "type": [Function],
         },
       ],
       "type": "div",


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@aea1ff52e04c1abe11b547e512b8d97e8bba3e1b
 * Sakuten/backend@87f92fe137d0707952d2c8c075fa7ea7d646a6f9

変更内容
================

  * メンバーリストのUIをちゃんと作った
  * Fix #96 

修正前の挙動:
-------------

  * UIがわかりにくい

修正後の挙動:
-------------

  * UIがわかりやすい

![9d31cba6 ngrok io_lottery iphone 6_7_8](https://user-images.githubusercontent.com/16184855/45269801-d71c0300-b4ce-11e8-9c65-5b876af7779c.png)


影響範囲
================

  * ない
