### PR TITLE
エラーをエラーコードとともに管理+日本語化して表示

### DIFF
--- a/src/__tests__/errors.spec.js
+++ b/src/__tests__/errors.spec.js
@@ -1,0 +1,10 @@
+import errors from '../errors.json'
+
+describe('errors.json', () => {
+  it('has "translation" and "level" key in each element', () => {
+    for (const code in errors) {
+      expect(errors[code].translation).toBeDefined()
+      expect(errors[code].level).toBeDefined()
+    }
+  })
+})

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import styled from 'styled-components'
+import errors from '../errors.json'
 
 const Container = styled.div`
   position: fixed;
@@ -12,17 +13,25 @@ const Container = styled.div`
 const ErrorList = ({list, onDelete}) => (
   <Container data-test='errorlist'>
     {
-      list.map((c, i) =>
-        <article data-test='errorlist-error' className='message is-danger' key={i} >
-          <div className='message-header'>
-            <p>エラーが発生しました</p>
-            <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
-          </div>
-          <div className='message-body'>
-            {JSON.stringify(c)}
-          </div>
-        </article>
-      )
+      list.map((c, i) => {
+        const error = errors[c.code]
+        const levelToMessage = {
+          'fault': '内部エラーが発生しました',
+          'error': 'エラーが発生しました',
+          'notice': '警告'
+        }
+        return (
+          <article data-test='errorlist-error' className='message is-danger' key={i} >
+            <div className='message-header'>
+              <p>{levelToMessage[error.level]}</p>
+              <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
+            </div>
+            <div className='message-body'>
+              {error.translation}
+            </div>
+          </article>
+        )
+      })
     }
   </Container>
 )

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -22,11 +22,11 @@ const ErrorList = ({list, onDelete}) => (
         }
         return (
           <article data-test='errorlist-error' className='message is-danger' key={i} >
-            <div className='message-header'>
+            <div data-test='errorlist-error-header' className='message-header'>
               <p>{levelToMessage[error.level]}</p>
               <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
-            <div className='message-body'>
+            <div data-test='errorlist-error-body' className='message-body'>
               {error.translation}
             </div>
           </article>

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -16,7 +16,7 @@ const ErrorList = ({list, onDelete}) => (
       list.map((c, i) => {
         const error = errors[c.code]
         const levelToMessage = {
-          'fault': '内部エラーが発生しました',
+          'internal': '内部エラーが発生しました',
           'error': 'エラーが発生しました',
           'notice': '警告'
         }

--- a/src/component/GroupMemberButton.js
+++ b/src/component/GroupMemberButton.js
@@ -39,7 +39,7 @@ import QRReader from '../component/QRReader'
     if (scanUri) {
       const secretId = extractId(scanUri)
       if (!secretId) {
-        this.store.error.addError('Invalid QR Code')
+        this.store.error.addError('101', 'Invalid QR Code')
         return
       }
 

--- a/src/component/__tests__/ErrorList.spec.js
+++ b/src/component/__tests__/ErrorList.spec.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import ErrorList from '../ErrorList'
+import errors from '../../errors.json'
 
 const setup = propOverrides => {
   const props = Object.assign({
@@ -14,7 +15,9 @@ const setup = propOverrides => {
   return {
     props,
     wrapper,
-    error: wrapper.find('[data-test="errorlist-error"]')
+    error: wrapper.find('[data-test="errorlist-error"]'),
+    header: wrapper.find('[data-test="errorlist-error-header"]'),
+    body: wrapper.find('[data-test="errorlist-error-body"]'),
   }
 }
 
@@ -28,6 +31,12 @@ describe('components', () => {
     it('renders two errors', () => {
       const { error } = setup()
       expect(error.length).toBe(2)
+    })
+
+    it('renders correct error message', () => {
+      const { body } = setup()
+      expect(body.at(0).text()).toBe(errors['0'].translation)
+      expect(body.at(1).text()).toBe(errors['1'].translation)
     })
   })
 })

--- a/src/component/__tests__/ErrorList.spec.js
+++ b/src/component/__tests__/ErrorList.spec.js
@@ -5,8 +5,8 @@ import ErrorList from '../ErrorList'
 const setup = propOverrides => {
   const props = Object.assign({
     list: [
-      { message: 'Error 1' },
-      { message: 'Error 2' }]
+      { code: 0, message: 'Error 1' },
+      { code: 1, message: 'Error 2' }]
   }, propOverrides)
 
   const wrapper = shallow(<ErrorList {...props} />)

--- a/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
@@ -7,9 +7,11 @@ ShallowWrapper {
     list={
       Array [
         Object {
+          "code": 0,
           "message": "Error 1",
         },
         Object {
+          "code": 1,
           "message": "Error 2",
         },
       ]
@@ -36,7 +38,7 @@ ShallowWrapper {
             className="message-header"
           >
             <p>
-              エラーが発生しました
+              警告
             </p>
             <button
               aria-label="delete"
@@ -47,7 +49,7 @@ ShallowWrapper {
           <div
             className="message-body"
           >
-            {"message":"Error 1"}
+            ログインしていません
           </div>
         </article>,
         <article
@@ -58,7 +60,7 @@ ShallowWrapper {
             className="message-header"
           >
             <p>
-              エラーが発生しました
+              内部エラーが発生しました
             </p>
             <button
               aria-label="delete"
@@ -69,7 +71,7 @@ ShallowWrapper {
           <div
             className="message-body"
           >
-            {"message":"Error 2"}
+            グループメンバーのカードが正しくありません。
           </div>
         </article>,
       ],
@@ -87,7 +89,7 @@ ShallowWrapper {
               className="message-header"
             >
               <p>
-                エラーが発生しました
+                警告
               </p>
               <button
                 aria-label="delete"
@@ -98,7 +100,7 @@ ShallowWrapper {
             <div
               className="message-body"
             >
-              {"message":"Error 1"}
+              ログインしていません
             </div>,
           ],
           "className": "message is-danger",
@@ -113,7 +115,7 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 <p>
-                  エラーが発生しました
+                  警告
                 </p>,
                 <button
                   aria-label="delete"
@@ -130,10 +132,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "エラーが発生しました",
+                  "children": "警告",
                 },
                 "ref": null,
-                "rendered": "エラーが発生しました",
+                "rendered": "警告",
                 "type": "p",
               },
               Object {
@@ -157,11 +159,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "{\\"message\\":\\"Error 1\\"}",
+              "children": "ログインしていません",
               "className": "message-body",
             },
             "ref": null,
-            "rendered": "{\\"message\\":\\"Error 1\\"}",
+            "rendered": "ログインしていません",
             "type": "div",
           },
         ],
@@ -177,7 +179,7 @@ ShallowWrapper {
               className="message-header"
             >
               <p>
-                エラーが発生しました
+                内部エラーが発生しました
               </p>
               <button
                 aria-label="delete"
@@ -188,7 +190,7 @@ ShallowWrapper {
             <div
               className="message-body"
             >
-              {"message":"Error 2"}
+              グループメンバーのカードが正しくありません。
             </div>,
           ],
           "className": "message is-danger",
@@ -203,7 +205,7 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 <p>
-                  エラーが発生しました
+                  内部エラーが発生しました
                 </p>,
                 <button
                   aria-label="delete"
@@ -220,10 +222,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "エラーが発生しました",
+                  "children": "内部エラーが発生しました",
                 },
                 "ref": null,
-                "rendered": "エラーが発生しました",
+                "rendered": "内部エラーが発生しました",
                 "type": "p",
               },
               Object {
@@ -247,11 +249,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "{\\"message\\":\\"Error 2\\"}",
+              "children": "グループメンバーのカードが正しくありません。",
               "className": "message-body",
             },
             "ref": null,
-            "rendered": "{\\"message\\":\\"Error 2\\"}",
+            "rendered": "グループメンバーのカードが正しくありません。",
             "type": "div",
           },
         ],
@@ -275,7 +277,7 @@ ShallowWrapper {
               className="message-header"
             >
               <p>
-                エラーが発生しました
+                警告
               </p>
               <button
                 aria-label="delete"
@@ -286,7 +288,7 @@ ShallowWrapper {
             <div
               className="message-body"
             >
-              {"message":"Error 1"}
+              ログインしていません
             </div>
           </article>,
           <article
@@ -297,7 +299,7 @@ ShallowWrapper {
               className="message-header"
             >
               <p>
-                エラーが発生しました
+                内部エラーが発生しました
               </p>
               <button
                 aria-label="delete"
@@ -308,7 +310,7 @@ ShallowWrapper {
             <div
               className="message-body"
             >
-              {"message":"Error 2"}
+              グループメンバーのカードが正しくありません。
             </div>
           </article>,
         ],
@@ -326,7 +328,7 @@ ShallowWrapper {
                 className="message-header"
               >
                 <p>
-                  エラーが発生しました
+                  警告
                 </p>
                 <button
                   aria-label="delete"
@@ -337,7 +339,7 @@ ShallowWrapper {
               <div
                 className="message-body"
               >
-                {"message":"Error 1"}
+                ログインしていません
               </div>,
             ],
             "className": "message is-danger",
@@ -352,7 +354,7 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   <p>
-                    エラーが発生しました
+                    警告
                   </p>,
                   <button
                     aria-label="delete"
@@ -369,10 +371,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "エラーが発生しました",
+                    "children": "警告",
                   },
                   "ref": null,
-                  "rendered": "エラーが発生しました",
+                  "rendered": "警告",
                   "type": "p",
                 },
                 Object {
@@ -396,11 +398,11 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "{\\"message\\":\\"Error 1\\"}",
+                "children": "ログインしていません",
                 "className": "message-body",
               },
               "ref": null,
-              "rendered": "{\\"message\\":\\"Error 1\\"}",
+              "rendered": "ログインしていません",
               "type": "div",
             },
           ],
@@ -416,7 +418,7 @@ ShallowWrapper {
                 className="message-header"
               >
                 <p>
-                  エラーが発生しました
+                  内部エラーが発生しました
                 </p>
                 <button
                   aria-label="delete"
@@ -427,7 +429,7 @@ ShallowWrapper {
               <div
                 className="message-body"
               >
-                {"message":"Error 2"}
+                グループメンバーのカードが正しくありません。
               </div>,
             ],
             "className": "message is-danger",
@@ -442,7 +444,7 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   <p>
-                    エラーが発生しました
+                    内部エラーが発生しました
                   </p>,
                   <button
                     aria-label="delete"
@@ -459,10 +461,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "エラーが発生しました",
+                    "children": "内部エラーが発生しました",
                   },
                   "ref": null,
-                  "rendered": "エラーが発生しました",
+                  "rendered": "内部エラーが発生しました",
                   "type": "p",
                 },
                 Object {
@@ -486,11 +488,11 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "{\\"message\\":\\"Error 2\\"}",
+                "children": "グループメンバーのカードが正しくありません。",
                 "className": "message-body",
               },
               "ref": null,
-              "rendered": "{\\"message\\":\\"Error 2\\"}",
+              "rendered": "グループメンバーのカードが正しくありません。",
               "type": "div",
             },
           ],

--- a/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
@@ -36,6 +36,7 @@ ShallowWrapper {
         >
           <div
             className="message-header"
+            data-test="errorlist-error-header"
           >
             <p>
               警告
@@ -48,6 +49,7 @@ ShallowWrapper {
           </div>
           <div
             className="message-body"
+            data-test="errorlist-error-body"
           >
             ログインしていません
           </div>
@@ -58,6 +60,7 @@ ShallowWrapper {
         >
           <div
             className="message-header"
+            data-test="errorlist-error-header"
           >
             <p>
               内部エラーが発生しました
@@ -70,6 +73,7 @@ ShallowWrapper {
           </div>
           <div
             className="message-body"
+            data-test="errorlist-error-body"
           >
             グループメンバーのカードが正しくありません。
           </div>
@@ -87,6 +91,7 @@ ShallowWrapper {
           "children": Array [
             <div
               className="message-header"
+              data-test="errorlist-error-header"
             >
               <p>
                 警告
@@ -99,6 +104,7 @@ ShallowWrapper {
             </div>,
             <div
               className="message-body"
+              data-test="errorlist-error-body"
             >
               ログインしていません
             </div>,
@@ -124,6 +130,7 @@ ShallowWrapper {
                 />,
               ],
               "className": "message-header",
+              "data-test": "errorlist-error-header",
             },
             "ref": null,
             "rendered": Array [
@@ -161,6 +168,7 @@ ShallowWrapper {
             "props": Object {
               "children": "ログインしていません",
               "className": "message-body",
+              "data-test": "errorlist-error-body",
             },
             "ref": null,
             "rendered": "ログインしていません",
@@ -177,6 +185,7 @@ ShallowWrapper {
           "children": Array [
             <div
               className="message-header"
+              data-test="errorlist-error-header"
             >
               <p>
                 内部エラーが発生しました
@@ -189,6 +198,7 @@ ShallowWrapper {
             </div>,
             <div
               className="message-body"
+              data-test="errorlist-error-body"
             >
               グループメンバーのカードが正しくありません。
             </div>,
@@ -214,6 +224,7 @@ ShallowWrapper {
                 />,
               ],
               "className": "message-header",
+              "data-test": "errorlist-error-header",
             },
             "ref": null,
             "rendered": Array [
@@ -251,6 +262,7 @@ ShallowWrapper {
             "props": Object {
               "children": "グループメンバーのカードが正しくありません。",
               "className": "message-body",
+              "data-test": "errorlist-error-body",
             },
             "ref": null,
             "rendered": "グループメンバーのカードが正しくありません。",
@@ -275,6 +287,7 @@ ShallowWrapper {
           >
             <div
               className="message-header"
+              data-test="errorlist-error-header"
             >
               <p>
                 警告
@@ -287,6 +300,7 @@ ShallowWrapper {
             </div>
             <div
               className="message-body"
+              data-test="errorlist-error-body"
             >
               ログインしていません
             </div>
@@ -297,6 +311,7 @@ ShallowWrapper {
           >
             <div
               className="message-header"
+              data-test="errorlist-error-header"
             >
               <p>
                 内部エラーが発生しました
@@ -309,6 +324,7 @@ ShallowWrapper {
             </div>
             <div
               className="message-body"
+              data-test="errorlist-error-body"
             >
               グループメンバーのカードが正しくありません。
             </div>
@@ -326,6 +342,7 @@ ShallowWrapper {
             "children": Array [
               <div
                 className="message-header"
+                data-test="errorlist-error-header"
               >
                 <p>
                   警告
@@ -338,6 +355,7 @@ ShallowWrapper {
               </div>,
               <div
                 className="message-body"
+                data-test="errorlist-error-body"
               >
                 ログインしていません
               </div>,
@@ -363,6 +381,7 @@ ShallowWrapper {
                   />,
                 ],
                 "className": "message-header",
+                "data-test": "errorlist-error-header",
               },
               "ref": null,
               "rendered": Array [
@@ -400,6 +419,7 @@ ShallowWrapper {
               "props": Object {
                 "children": "ログインしていません",
                 "className": "message-body",
+                "data-test": "errorlist-error-body",
               },
               "ref": null,
               "rendered": "ログインしていません",
@@ -416,6 +436,7 @@ ShallowWrapper {
             "children": Array [
               <div
                 className="message-header"
+                data-test="errorlist-error-header"
               >
                 <p>
                   内部エラーが発生しました
@@ -428,6 +449,7 @@ ShallowWrapper {
               </div>,
               <div
                 className="message-body"
+                data-test="errorlist-error-body"
               >
                 グループメンバーのカードが正しくありません。
               </div>,
@@ -453,6 +475,7 @@ ShallowWrapper {
                   />,
                 ],
                 "className": "message-header",
+                "data-test": "errorlist-error-header",
               },
               "ref": null,
               "rendered": Array [
@@ -490,6 +513,7 @@ ShallowWrapper {
               "props": Object {
                 "children": "グループメンバーのカードが正しくありません。",
                 "className": "message-body",
+                "data-test": "errorlist-error-body",
               },
               "ref": null,
               "rendered": "グループメンバーのカードが正しくありません。",

--- a/src/errors.json
+++ b/src/errors.json
@@ -102,5 +102,9 @@
   "104": {
     "translation": "4人以上の同時応募はできません。",
     "level": "error"
+  },
+  "105": {
+    "translation": "ネットワークエラー",
+    "level": "fault"
   }
 }

--- a/src/errors.json
+++ b/src/errors.json
@@ -86,5 +86,21 @@
   "21": {
     "translation": "4人以上の同時応募はできません。",
     "level": "error"
+  },
+  "101": {
+    "translation": "読み取りに失敗しました。もう一度お試しください。",
+    "level": "notice"
+  },
+  "102": {
+    "translation": "あなた自身をメンバーとして追加することはできません",
+    "level": "error"
+  },
+  "103": {
+    "translation": "すでに追加されているメンバーです",
+    "level": "error"
+  },
+  "104": {
+    "translation": "4人以上の同時応募はできません。",
+    "level": "error"
   }
 }

--- a/src/errors.json
+++ b/src/errors.json
@@ -1,0 +1,90 @@
+{
+  "00": {
+    "translation": "ログインしていません",
+    "level": "notice"
+  },
+  "01": {
+    "translation": "グループメンバーのカードが正しくありません。",
+    "level": "fault"
+  },
+  "02": {
+    "translation": "不正なリクエストが検出されました",
+    "level": "fault"
+  },
+  "03": {
+    "translation": "ログインに失敗しました。もう一度お試しください。",
+    "level": "error"
+  },
+  "04": {
+    "translation": "不正なログインが検出されました",
+    "level": "fault"
+  },
+  "05": {
+    "translation": "ユーザーが見つかりません",
+    "level": "fault"
+  },
+  "06": {
+    "translation": "現在は受けつけておりません。",
+    "level": "notice"
+  },
+  "07": {
+    "translation": "見つかりません",
+    "level": "error"
+  },
+  "08": {
+    "translation": "グループメンバーの中に、すでにこの時間帯で応募している人がいます",
+    "level": "error"
+  },
+  "09": {
+    "translation": "グループメンバーの中に、すでにこの抽選に応募している人がいます",
+    "level": "error"
+  },
+  "10": {
+    "translation": "すでに終わった応募をキャンセルすることはできません。",
+    "level": "error"
+  },
+  "11": {
+    "translation": "この抽選への応募は、現在は受けつけておりません。",
+    "level": "error"
+  },
+  "12": {
+    "translation": "まだ抽選が行われていません。",
+    "level": "notice"
+  },
+  "13": {
+    "translation": "不正なリクエストが検出されました",
+    "level": "fault"
+  },
+  "14": {
+    "translation": "現在は受けつけておりません。",
+    "level": "error"
+  },
+  "15": {
+    "translation": "不正なリクエストが検出されました",
+    "level": "fault"
+  },
+  "16": {
+    "translation": "すでに応募しています",
+    "level": "error"
+  },
+  "17": {
+    "translation": "すでにこの時間帯で応募しています",
+    "level": "error"
+  },
+  "18": {
+    "translation": "現在は受けつけておりません。",
+    "level": "fault"
+  },
+  "19": {
+    "translation": "応募していません。",
+    "level": "error"
+  },
+  "20": {
+    "translation": "内部エラーが発生しました。もう一度お試しください。",
+    "level": "fault"
+  },
+  "21": {
+    "translation": "4人以上の同時応募はできません。",
+    "level": "error"
+  }
+}

--- a/src/errors.json
+++ b/src/errors.json
@@ -5,11 +5,11 @@
   },
   "01": {
     "translation": "グループメンバーのカードが正しくありません。",
-    "level": "fault"
+    "level": "internal"
   },
   "02": {
     "translation": "不正なリクエストが検出されました",
-    "level": "fault"
+    "level": "internal"
   },
   "03": {
     "translation": "ログインに失敗しました。もう一度お試しください。",
@@ -17,11 +17,11 @@
   },
   "04": {
     "translation": "不正なログインが検出されました",
-    "level": "fault"
+    "level": "internal"
   },
   "05": {
     "translation": "ユーザーが見つかりません",
-    "level": "fault"
+    "level": "internal"
   },
   "06": {
     "translation": "現在は受けつけておりません。",
@@ -53,7 +53,7 @@
   },
   "13": {
     "translation": "不正なリクエストが検出されました",
-    "level": "fault"
+    "level": "internal"
   },
   "14": {
     "translation": "現在は受けつけておりません。",
@@ -61,7 +61,7 @@
   },
   "15": {
     "translation": "不正なリクエストが検出されました",
-    "level": "fault"
+    "level": "internal"
   },
   "16": {
     "translation": "すでに応募しています",
@@ -73,7 +73,7 @@
   },
   "18": {
     "translation": "現在は受けつけておりません。",
-    "level": "fault"
+    "level": "internal"
   },
   "19": {
     "translation": "応募していません。",
@@ -81,7 +81,7 @@
   },
   "20": {
     "translation": "内部エラーが発生しました。もう一度お試しください。",
-    "level": "fault"
+    "level": "internal"
   },
   "21": {
     "translation": "4人以上の同時応募はできません。",
@@ -105,6 +105,6 @@
   },
   "105": {
     "translation": "ネットワークエラー",
-    "level": "fault"
+    "level": "internal"
   }
 }

--- a/src/errors.json
+++ b/src/errors.json
@@ -1,41 +1,41 @@
 {
-  "00": {
+  "0": {
     "translation": "ログインしていません",
     "level": "notice"
   },
-  "01": {
+  "1": {
     "translation": "グループメンバーのカードが正しくありません。",
     "level": "internal"
   },
-  "02": {
+  "2": {
     "translation": "不正なリクエストが検出されました",
     "level": "internal"
   },
-  "03": {
+  "3": {
     "translation": "ログインに失敗しました。もう一度お試しください。",
     "level": "error"
   },
-  "04": {
+  "4": {
     "translation": "不正なログインが検出されました",
     "level": "internal"
   },
-  "05": {
+  "5": {
     "translation": "ユーザーが見つかりません",
     "level": "internal"
   },
-  "06": {
+  "6": {
     "translation": "現在は受けつけておりません。",
     "level": "notice"
   },
-  "07": {
+  "7": {
     "translation": "見つかりません",
     "level": "error"
   },
-  "08": {
+  "8": {
     "translation": "グループメンバーの中に、すでにこの時間帯で応募している人がいます",
     "level": "error"
   },
-  "09": {
+  "9": {
     "translation": "グループメンバーの中に、すでにこの抽選に応募している人がいます",
     "level": "error"
   },

--- a/src/event/__tests__/error.spec.js
+++ b/src/event/__tests__/error.spec.js
@@ -20,7 +20,7 @@ describe('events', () => {
 
     it('clears token when unauthorized', () => {
       event.store.credential.token = 'token'
-      event.onError({'message': 'Unauthorized'})
+      event.onError(0, 'Unauthorized')
       expect(event.store.credential.token.length).toBe(0)
     })
   })

--- a/src/event/application.js
+++ b/src/event/application.js
@@ -23,15 +23,15 @@ export class ApplicationObject {
 
   onAddGroupMember = async (secretId) => {
     if (this.store.credential.status.get('secret_id') === secretId) {
-      this.store.error.addError('You can\'t add yourself as a member')
+      this.store.error.addError(102, 'You can\'t add yourself as a member')
       return
     }
     if (this.store.application.groupMemberList.indexOf(secretId) !== -1) {
-      this.store.error.addError('The user is already in the member list')
+      this.store.error.addError(103, 'The user is already in the member list')
       return
     }
     if (!this.store.application.isAbleToAddGroupMember) {
-      this.store.error.addError('Too many group members')
+      this.store.error.addError(104, 'Too many group members')
       return
     }
     const resp = await getPublicId(secretId, this.store.credential.token)

--- a/src/event/checker.js
+++ b/src/event/checker.js
@@ -19,7 +19,7 @@ export class CheckerObject {
       this.lastScan = scanUri
       const secretId = extractId(scanUri)
       if (!secretId) {
-        this.store.error.addError('Invalid QR Code')
+        this.store.error.addError(101, 'Invalid QR Code')
         return
       }
 

--- a/src/event/credential.js
+++ b/src/event/credential.js
@@ -34,14 +34,14 @@ export class CredentialObject {
   }
 
   onQRError = (error) => {
-    this.store.error.addError(error)
+    this.store.error.addError(101, error)
   }
 
   onQRScan = (scanUri) => {
     if (scanUri) {
       const secretId = extractId(scanUri)
       if (!secretId) {
-        this.store.error.addError('Invalid QR Code')
+        this.store.error.addError(101, 'Invalid QR Code')
         return
       }
 

--- a/src/event/error.js
+++ b/src/event/error.js
@@ -8,17 +8,17 @@ export class ErrorObject {
       response => response,
       error => {
         const message = error.response ? error.response.data : (error.request ? error.request : error.message)
-        this.onError(message)
+        this.onError(message.code, message.message)
         return Promise.reject(error)
       }
     )
   }
 
-  onError = (message) => {
-    if ('message' in message && message['message'] === 'Unauthorized') {
+  onError = (code, message) => {
+    if (message === 'Unauthorized') {
       this.store.credential.setToken('')
     }
-    this.store.error.addError(message)
+    this.store.error.addError(code, message)
   }
 
   onDelete = (idx) => {

--- a/src/event/error.js
+++ b/src/event/error.js
@@ -15,7 +15,7 @@ export class ErrorObject {
   }
 
   onError = (code, message) => {
-    if (message === 'Unauthorized') {
+    if (code === 0) {
       this.store.credential.setToken('')
     }
     this.store.error.addError(code, message)

--- a/src/event/error.js
+++ b/src/event/error.js
@@ -8,7 +8,11 @@ export class ErrorObject {
       response => response,
       error => {
         const message = error.response ? error.response.data : (error.request ? error.request : error.message)
-        this.onError(message.code, message.message)
+        if (typeof message === 'object' && 'code' in message) {
+          this.onError(message.code, message)
+        } else {
+          this.onError(105, message)
+        }
         return Promise.reject(error)
       }
     )

--- a/src/store/__tests__/error.spec.js
+++ b/src/store/__tests__/error.spec.js
@@ -9,11 +9,11 @@ describe('stores', () => {
     })
 
     it('creates new errors', () => {
-      store.addError('Error1')
-      store.addError('Error2')
+      store.addError(0, 'Error1')
+      store.addError(1, 'Error2')
       expect(store.errorList.length).toBe(2)
-      expect(store.errorList[0]).toBe('Error1')
-      expect(store.errorList[1]).toBe('Error2')
+      expect(store.errorList[0]).toEqual({code: 0, message: 'Error1'})
+      expect(store.errorList[1]).toEqual({code: 1, message: 'Error2'})
     })
   })
 })

--- a/src/store/error.js
+++ b/src/store/error.js
@@ -22,11 +22,11 @@ export class ErrorObject {
     return proc(deleter)
   }
 
-  @action.bound addError (message) {
-    if (typeof message === 'object' && 'code' in message && this.ignoreErrorCodeList.indexOf(message.code) !== -1) {
+  @action.bound addError (code, message) {
+    if (this.ignoreErrorCodeList.indexOf(code) !== -1) {
       return
     }
-    this.errorList.push(message)
+    this.errorList.push({code: code, message: message})
   }
 
   @action.bound deleteError (idx) {


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@dd12c3f5c645c91c81de4a4c7184e57fa5734c88
 * Sakuten/backend@b317307e2fd07356e25d2278d238fb6d14c846f7

変更内容
================

  * エラーを構造化
  * エラーを日本語化
  * Fix #99 
  * Fix #86 

修正前の挙動:
-------------

  * エラーは気ままにJSONのまま出てくる

修正後の挙動:
-------------

  * 日本語化されたエラーメッセージ

影響範囲
================

  * なさそう