### PR TITLE
Fulfilledなapplicationにcancelをつけない

### DIFF
--- a/src/component/ApplicationList.js
+++ b/src/component/ApplicationList.js
@@ -22,9 +22,9 @@ const ApplicationList = ({list, onCancel}) => (
                 <StatusTag status={c.status} />
               </TagWrapper>
             </header>
-            <footer className='card-footer'>
+            {c.status === 'pending' && <footer className='card-footer'>
               <a className='card-footer-item has-text-danger' data-test='applicationlist-cancel' onClick={() => onCancel(c.id)}>キャンセル</a>
-            </footer>
+            </footer>}
           </div>
         </div>
       ) : <span data-test='applicationlist-notfound'>まだどのクラスにも応募していません。</span>

--- a/src/component/__tests__/ApplicationList.spec.js
+++ b/src/component/__tests__/ApplicationList.spec.js
@@ -73,7 +73,7 @@ describe('components', () => {
 
     it('calls onCancel with application id when cancel button is clicked', () => {
       const mock = jest.fn()
-      const { cancelButton } = setup({list: [{id: 1, lottery: {name: '5A.0'}}], onCancel: mock})
+      const { cancelButton } = setup({list: [{id: 1, status: 'pending', lottery: {name: '5A.0'}}], onCancel: mock})
       cancelButton.at(0).simulate('click')
       expect(mock).toBeCalledWith(1)
     })

--- a/src/component/__tests__/ApplicationList.spec.js
+++ b/src/component/__tests__/ApplicationList.spec.js
@@ -66,6 +66,11 @@ describe('components', () => {
       expect(cancelButton.length).toBe(2)
     })
 
+    it('renders no cancel button when status !== pending', () => {
+      const { cancelButton } = setup({list: [{id: 1, status: 'won', lottery: {name: '5A.0'}}]})
+      expect(cancelButton.length).toBe(0)
+    })
+
     it('calls onCancel with application id when cancel button is clicked', () => {
       const mock = jest.fn()
       const { cancelButton } = setup({list: [{id: 1, lottery: {name: '5A.0'}}], onCancel: mock})


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@d85b42dea2ecffcaea7f42f01415675c1301f4e2
 * Sakuten/backend@b6672e0459cf1e5f716bcbbfd7da29ab240b9c0c

変更内容
================

  * Fix #82

修正前の挙動:
-------------

  * Fulfilledなapplicationにcancelがある

修正後の挙動:
-------------

  * 無い

影響範囲
================

  * 無い
