### PR TITLE
Show 'OK' Button on error message

### DIFF
--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -20,10 +20,11 @@ const ErrorList = ({list, onDelete}) => (
           'error': ['is-warning', '失敗しました'],
           'notice': ['is-info', '情報']
         }
+        const msg = levelToMessage[error.level]
         return (
-          <article data-test='errorlist-error' className={`message ${levelToMessage[error.level][0]}`} key={i} >
+          <article data-test='errorlist-error' className={`message ${msg[0]}`} key={i} >
             <div data-test='errorlist-error-header' className='message-header'>
-              <p>{levelToMessage[error.level][1]}</p>
+              <p>{msg[1]}</p>
               <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
             <div data-test='errorlist-error-body' className='message-body'>

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -10,6 +10,16 @@ const Container = styled.div`
   z-index: 10;
 `
 
+const MessageContainer = styled.div.attrs({
+  className: 'message-body'
+})`
+  display: flex;
+`
+
+const MessageBody = styled.span`
+  flex-grow: 1;
+`
+
 const ErrorList = ({list, onDelete}) => (
   <Container data-test='errorlist'>
     {
@@ -27,14 +37,14 @@ const ErrorList = ({list, onDelete}) => (
               <p>{msg[1]}</p>
               <button data-test='errorlist-error-close-button' className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
-            <div className='message-body'>
-              <span data-test='errorlist-error-body'>
+            <MessageContainer className='message-body'>
+              <MessageBody data-test='errorlist-error-body'>
                 {error.translation}
-              </span>
+              </MessageBody>
               {error.level !== 'internal' && <button data-test='errorlist-error-ok-button' className='button is-info' onClick={() => onDelete(i)}>
                 OK
               </button>}
-            </div>
+            </MessageContainer>
           </article>
         )
       })

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -25,13 +25,13 @@ const ErrorList = ({list, onDelete}) => (
           <article data-test='errorlist-error' className={`message ${msg[0]}`} key={i} >
             <div data-test='errorlist-error-header' className='message-header'>
               <p>{msg[1]}</p>
-              <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
+              <button data-test='errorlist-error-close-button' className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
-            <div data-test='errorlist-error-body' className='message-body'>
-              <span>
+            <div className='message-body'>
+              <span data-test='errorlist-error-body'>
                 {error.translation}
               </span>
-              {error.level !== 'internal' && <button className='button is-info' onClick={() => onDelete(i)}>
+              {error.level !== 'internal' && <button data-test='errorlist-error-ok-button' className='button is-info' onClick={() => onDelete(i)}>
                 OK
               </button>}
             </div>

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -27,7 +27,12 @@ const ErrorList = ({list, onDelete}) => (
               <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
             <div data-test='errorlist-error-body' className='message-body'>
-              {error.translation}
+              <span>
+                {error.translation}
+              </span>
+              <button className='button is-info' onClick={() => onDelete(i)}>
+                OK
+              </button>
             </div>
           </article>
         )

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -16,14 +16,14 @@ const ErrorList = ({list, onDelete}) => (
       list.map((c, i) => {
         const error = errors[c.code]
         const levelToMessage = {
-          'internal': '内部エラーが発生しました',
-          'error': 'エラーが発生しました',
-          'notice': '警告'
+          'internal': ['is-danger', '内部エラーが発生しました'],
+          'error': ['is-warning', '失敗しました'],
+          'notice': ['is-info', '情報']
         }
         return (
-          <article data-test='errorlist-error' className='message is-danger' key={i} >
+          <article data-test='errorlist-error' className={`message ${levelToMessage[error.level][0]}`} key={i} >
             <div data-test='errorlist-error-header' className='message-header'>
-              <p>{levelToMessage[error.level]}</p>
+              <p>{levelToMessage[error.level][1]}</p>
               <button className='delete' aria-label='delete' onClick={() => onDelete(i)} />
             </div>
             <div data-test='errorlist-error-body' className='message-body'>

--- a/src/component/ErrorList.js
+++ b/src/component/ErrorList.js
@@ -30,9 +30,9 @@ const ErrorList = ({list, onDelete}) => (
               <span>
                 {error.translation}
               </span>
-              <button className='button is-info' onClick={() => onDelete(i)}>
+              {error.level !== 'internal' && <button className='button is-info' onClick={() => onDelete(i)}>
                 OK
-              </button>
+              </button>}
             </div>
           </article>
         )

--- a/src/component/__tests__/ErrorList.spec.js
+++ b/src/component/__tests__/ErrorList.spec.js
@@ -17,7 +17,9 @@ const setup = propOverrides => {
     wrapper,
     error: wrapper.find('[data-test="errorlist-error"]'),
     header: wrapper.find('[data-test="errorlist-error-header"]'),
-    body: wrapper.find('[data-test="errorlist-error-body"]')
+    body: wrapper.find('[data-test="errorlist-error-body"]'),
+    okButtton: wrapper.find('[data-test="errorlist-error-ok-button"]'),
+    closeButton: wrapper.find('[data-test="errorlist-error-close-button"]')
   }
 }
 
@@ -37,6 +39,13 @@ describe('components', () => {
       const { body } = setup()
       expect(body.at(0).text()).toBe(errors['0'].translation)
       expect(body.at(1).text()).toBe(errors['1'].translation)
+    })
+
+    it('closes when clicked', () => {
+      const mock = jest.fn()
+      const { closeButton } = setup({onDelete: mock})
+      closeButton.at(0).simulate('click')
+      expect(mock).toBeCalled()
     })
   })
 })

--- a/src/component/__tests__/ErrorList.spec.js
+++ b/src/component/__tests__/ErrorList.spec.js
@@ -37,8 +37,9 @@ describe('components', () => {
 
     it('renders correct error message', () => {
       const { body } = setup()
-      expect(body.at(0).text()).toBe(errors['0'].translation)
-      expect(body.at(1).text()).toBe(errors['1'].translation)
+      // children() because of styled-components
+      expect(body.at(0).children().text()).toBe(errors['0'].translation)
+      expect(body.at(1).children().text()).toBe(errors['1'].translation)
     })
 
     it('closes when clicked', () => {

--- a/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
@@ -50,9 +50,10 @@ ShallowWrapper {
           </div>
           <div
             className="message-body"
-            data-test="errorlist-error-body"
           >
-            <span>
+            <span
+              data-test="errorlist-error-body"
+            >
               ログインしていません
             </span>
             <button
@@ -84,9 +85,10 @@ ShallowWrapper {
           </div>
           <div
             className="message-body"
-            data-test="errorlist-error-body"
           >
-            <span>
+            <span
+              data-test="errorlist-error-body"
+            >
               グループメンバーのカードが正しくありません。
             </span>
           </div>
@@ -118,9 +120,10 @@ ShallowWrapper {
             </div>,
             <div
               className="message-body"
-              data-test="errorlist-error-body"
             >
-              <span>
+              <span
+                data-test="errorlist-error-body"
+              >
                 ログインしていません
               </span>
               <button
@@ -192,7 +195,9 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <span>
+                <span
+                  data-test="errorlist-error-body"
+                >
                   ログインしていません
                 </span>,
                 <button
@@ -204,7 +209,6 @@ ShallowWrapper {
                 </button>,
               ],
               "className": "message-body",
-              "data-test": "errorlist-error-body",
             },
             "ref": null,
             "rendered": Array [
@@ -214,6 +218,7 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": "ログインしていません",
+                  "data-test": "errorlist-error-body",
                 },
                 "ref": null,
                 "rendered": "ログインしていません",
@@ -261,9 +266,10 @@ ShallowWrapper {
             </div>,
             <div
               className="message-body"
-              data-test="errorlist-error-body"
             >
-              <span>
+              <span
+                data-test="errorlist-error-body"
+              >
                 グループメンバーのカードが正しくありません。
               </span>
             </div>,
@@ -328,13 +334,14 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <span>
+                <span
+                  data-test="errorlist-error-body"
+                >
                   グループメンバーのカードが正しくありません。
                 </span>,
                 false,
               ],
               "className": "message-body",
-              "data-test": "errorlist-error-body",
             },
             "ref": null,
             "rendered": Array [
@@ -344,6 +351,7 @@ ShallowWrapper {
                 "nodeType": "host",
                 "props": Object {
                   "children": "グループメンバーのカードが正しくありません。",
+                  "data-test": "errorlist-error-body",
                 },
                 "ref": null,
                 "rendered": "グループメンバーのカードが正しくありません。",
@@ -386,9 +394,10 @@ ShallowWrapper {
             </div>
             <div
               className="message-body"
-              data-test="errorlist-error-body"
             >
-              <span>
+              <span
+                data-test="errorlist-error-body"
+              >
                 ログインしていません
               </span>
               <button
@@ -420,9 +429,10 @@ ShallowWrapper {
             </div>
             <div
               className="message-body"
-              data-test="errorlist-error-body"
             >
-              <span>
+              <span
+                data-test="errorlist-error-body"
+              >
                 グループメンバーのカードが正しくありません。
               </span>
             </div>
@@ -454,9 +464,10 @@ ShallowWrapper {
               </div>,
               <div
                 className="message-body"
-                data-test="errorlist-error-body"
               >
-                <span>
+                <span
+                  data-test="errorlist-error-body"
+                >
                   ログインしていません
                 </span>
                 <button
@@ -528,7 +539,9 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  <span>
+                  <span
+                    data-test="errorlist-error-body"
+                  >
                     ログインしていません
                   </span>,
                   <button
@@ -540,7 +553,6 @@ ShallowWrapper {
                   </button>,
                 ],
                 "className": "message-body",
-                "data-test": "errorlist-error-body",
               },
               "ref": null,
               "rendered": Array [
@@ -550,6 +562,7 @@ ShallowWrapper {
                   "nodeType": "host",
                   "props": Object {
                     "children": "ログインしていません",
+                    "data-test": "errorlist-error-body",
                   },
                   "ref": null,
                   "rendered": "ログインしていません",
@@ -597,9 +610,10 @@ ShallowWrapper {
               </div>,
               <div
                 className="message-body"
-                data-test="errorlist-error-body"
               >
-                <span>
+                <span
+                  data-test="errorlist-error-body"
+                >
                   グループメンバーのカードが正しくありません。
                 </span>
               </div>,
@@ -664,13 +678,14 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  <span>
+                  <span
+                    data-test="errorlist-error-body"
+                  >
                     グループメンバーのカードが正しくありません。
                   </span>,
                   false,
                 ],
                 "className": "message-body",
-                "data-test": "errorlist-error-body",
               },
               "ref": null,
               "rendered": Array [
@@ -680,6 +695,7 @@ ShallowWrapper {
                   "nodeType": "host",
                   "props": Object {
                     "children": "グループメンバーのカードが正しくありません。",
+                    "data-test": "errorlist-error-body",
                   },
                   "ref": null,
                   "rendered": "グループメンバーのカードが正しくありません。",

--- a/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
@@ -31,7 +31,7 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         <article
-          className="message is-danger"
+          className="message is-info"
           data-test="errorlist-error"
         >
           <div
@@ -39,11 +39,12 @@ ShallowWrapper {
             data-test="errorlist-error-header"
           >
             <p>
-              警告
+              情報
             </p>
             <button
               aria-label="delete"
               className="delete"
+              data-test="errorlist-error-close-button"
               onClick={[Function]}
             />
           </div>
@@ -51,7 +52,16 @@ ShallowWrapper {
             className="message-body"
             data-test="errorlist-error-body"
           >
-            ログインしていません
+            <span>
+              ログインしていません
+            </span>
+            <button
+              className="button is-info"
+              data-test="errorlist-error-ok-button"
+              onClick={[Function]}
+            >
+              OK
+            </button>
           </div>
         </article>,
         <article
@@ -68,6 +78,7 @@ ShallowWrapper {
             <button
               aria-label="delete"
               className="delete"
+              data-test="errorlist-error-close-button"
               onClick={[Function]}
             />
           </div>
@@ -75,7 +86,9 @@ ShallowWrapper {
             className="message-body"
             data-test="errorlist-error-body"
           >
-            グループメンバーのカードが正しくありません。
+            <span>
+              グループメンバーのカードが正しくありません。
+            </span>
           </div>
         </article>,
       ],
@@ -94,11 +107,12 @@ ShallowWrapper {
               data-test="errorlist-error-header"
             >
               <p>
-                警告
+                情報
               </p>
               <button
                 aria-label="delete"
                 className="delete"
+                data-test="errorlist-error-close-button"
                 onClick={[Function]}
               />
             </div>,
@@ -106,10 +120,19 @@ ShallowWrapper {
               className="message-body"
               data-test="errorlist-error-body"
             >
-              ログインしていません
+              <span>
+                ログインしていません
+              </span>
+              <button
+                className="button is-info"
+                data-test="errorlist-error-ok-button"
+                onClick={[Function]}
+              >
+                OK
+              </button>
             </div>,
           ],
-          "className": "message is-danger",
+          "className": "message is-info",
           "data-test": "errorlist-error",
         },
         "ref": null,
@@ -121,11 +144,12 @@ ShallowWrapper {
             "props": Object {
               "children": Array [
                 <p>
-                  警告
+                  情報
                 </p>,
                 <button
                   aria-label="delete"
                   className="delete"
+                  data-test="errorlist-error-close-button"
                   onClick={[Function]}
                 />,
               ],
@@ -139,10 +163,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "警告",
+                  "children": "情報",
                 },
                 "ref": null,
-                "rendered": "警告",
+                "rendered": "情報",
                 "type": "p",
               },
               Object {
@@ -152,6 +176,7 @@ ShallowWrapper {
                 "props": Object {
                   "aria-label": "delete",
                   "className": "delete",
+                  "data-test": "errorlist-error-close-button",
                   "onClick": [Function],
                 },
                 "ref": null,
@@ -166,12 +191,49 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "ログインしていません",
+              "children": Array [
+                <span>
+                  ログインしていません
+                </span>,
+                <button
+                  className="button is-info"
+                  data-test="errorlist-error-ok-button"
+                  onClick={[Function]}
+                >
+                  OK
+                </button>,
+              ],
               "className": "message-body",
               "data-test": "errorlist-error-body",
             },
             "ref": null,
-            "rendered": "ログインしていません",
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "ログインしていません",
+                },
+                "ref": null,
+                "rendered": "ログインしていません",
+                "type": "span",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "OK",
+                  "className": "button is-info",
+                  "data-test": "errorlist-error-ok-button",
+                  "onClick": [Function],
+                },
+                "ref": null,
+                "rendered": "OK",
+                "type": "button",
+              },
+            ],
             "type": "div",
           },
         ],
@@ -193,6 +255,7 @@ ShallowWrapper {
               <button
                 aria-label="delete"
                 className="delete"
+                data-test="errorlist-error-close-button"
                 onClick={[Function]}
               />
             </div>,
@@ -200,7 +263,9 @@ ShallowWrapper {
               className="message-body"
               data-test="errorlist-error-body"
             >
-              グループメンバーのカードが正しくありません。
+              <span>
+                グループメンバーのカードが正しくありません。
+              </span>
             </div>,
           ],
           "className": "message is-danger",
@@ -220,6 +285,7 @@ ShallowWrapper {
                 <button
                   aria-label="delete"
                   className="delete"
+                  data-test="errorlist-error-close-button"
                   onClick={[Function]}
                 />,
               ],
@@ -246,6 +312,7 @@ ShallowWrapper {
                 "props": Object {
                   "aria-label": "delete",
                   "className": "delete",
+                  "data-test": "errorlist-error-close-button",
                   "onClick": [Function],
                 },
                 "ref": null,
@@ -260,12 +327,30 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "グループメンバーのカードが正しくありません。",
+              "children": Array [
+                <span>
+                  グループメンバーのカードが正しくありません。
+                </span>,
+                false,
+              ],
               "className": "message-body",
               "data-test": "errorlist-error-body",
             },
             "ref": null,
-            "rendered": "グループメンバーのカードが正しくありません。",
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "グループメンバーのカードが正しくありません。",
+                },
+                "ref": null,
+                "rendered": "グループメンバーのカードが正しくありません。",
+                "type": "span",
+              },
+              false,
+            ],
             "type": "div",
           },
         ],
@@ -282,7 +367,7 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           <article
-            className="message is-danger"
+            className="message is-info"
             data-test="errorlist-error"
           >
             <div
@@ -290,11 +375,12 @@ ShallowWrapper {
               data-test="errorlist-error-header"
             >
               <p>
-                警告
+                情報
               </p>
               <button
                 aria-label="delete"
                 className="delete"
+                data-test="errorlist-error-close-button"
                 onClick={[Function]}
               />
             </div>
@@ -302,7 +388,16 @@ ShallowWrapper {
               className="message-body"
               data-test="errorlist-error-body"
             >
-              ログインしていません
+              <span>
+                ログインしていません
+              </span>
+              <button
+                className="button is-info"
+                data-test="errorlist-error-ok-button"
+                onClick={[Function]}
+              >
+                OK
+              </button>
             </div>
           </article>,
           <article
@@ -319,6 +414,7 @@ ShallowWrapper {
               <button
                 aria-label="delete"
                 className="delete"
+                data-test="errorlist-error-close-button"
                 onClick={[Function]}
               />
             </div>
@@ -326,7 +422,9 @@ ShallowWrapper {
               className="message-body"
               data-test="errorlist-error-body"
             >
-              グループメンバーのカードが正しくありません。
+              <span>
+                グループメンバーのカードが正しくありません。
+              </span>
             </div>
           </article>,
         ],
@@ -345,11 +443,12 @@ ShallowWrapper {
                 data-test="errorlist-error-header"
               >
                 <p>
-                  警告
+                  情報
                 </p>
                 <button
                   aria-label="delete"
                   className="delete"
+                  data-test="errorlist-error-close-button"
                   onClick={[Function]}
                 />
               </div>,
@@ -357,10 +456,19 @@ ShallowWrapper {
                 className="message-body"
                 data-test="errorlist-error-body"
               >
-                ログインしていません
+                <span>
+                  ログインしていません
+                </span>
+                <button
+                  className="button is-info"
+                  data-test="errorlist-error-ok-button"
+                  onClick={[Function]}
+                >
+                  OK
+                </button>
               </div>,
             ],
-            "className": "message is-danger",
+            "className": "message is-info",
             "data-test": "errorlist-error",
           },
           "ref": null,
@@ -372,11 +480,12 @@ ShallowWrapper {
               "props": Object {
                 "children": Array [
                   <p>
-                    警告
+                    情報
                   </p>,
                   <button
                     aria-label="delete"
                     className="delete"
+                    data-test="errorlist-error-close-button"
                     onClick={[Function]}
                   />,
                 ],
@@ -390,10 +499,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "警告",
+                    "children": "情報",
                   },
                   "ref": null,
-                  "rendered": "警告",
+                  "rendered": "情報",
                   "type": "p",
                 },
                 Object {
@@ -403,6 +512,7 @@ ShallowWrapper {
                   "props": Object {
                     "aria-label": "delete",
                     "className": "delete",
+                    "data-test": "errorlist-error-close-button",
                     "onClick": [Function],
                   },
                   "ref": null,
@@ -417,12 +527,49 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "ログインしていません",
+                "children": Array [
+                  <span>
+                    ログインしていません
+                  </span>,
+                  <button
+                    className="button is-info"
+                    data-test="errorlist-error-ok-button"
+                    onClick={[Function]}
+                  >
+                    OK
+                  </button>,
+                ],
                 "className": "message-body",
                 "data-test": "errorlist-error-body",
               },
               "ref": null,
-              "rendered": "ログインしていません",
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "ログインしていません",
+                  },
+                  "ref": null,
+                  "rendered": "ログインしていません",
+                  "type": "span",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "OK",
+                    "className": "button is-info",
+                    "data-test": "errorlist-error-ok-button",
+                    "onClick": [Function],
+                  },
+                  "ref": null,
+                  "rendered": "OK",
+                  "type": "button",
+                },
+              ],
               "type": "div",
             },
           ],
@@ -444,6 +591,7 @@ ShallowWrapper {
                 <button
                   aria-label="delete"
                   className="delete"
+                  data-test="errorlist-error-close-button"
                   onClick={[Function]}
                 />
               </div>,
@@ -451,7 +599,9 @@ ShallowWrapper {
                 className="message-body"
                 data-test="errorlist-error-body"
               >
-                グループメンバーのカードが正しくありません。
+                <span>
+                  グループメンバーのカードが正しくありません。
+                </span>
               </div>,
             ],
             "className": "message is-danger",
@@ -471,6 +621,7 @@ ShallowWrapper {
                   <button
                     aria-label="delete"
                     className="delete"
+                    data-test="errorlist-error-close-button"
                     onClick={[Function]}
                   />,
                 ],
@@ -497,6 +648,7 @@ ShallowWrapper {
                   "props": Object {
                     "aria-label": "delete",
                     "className": "delete",
+                    "data-test": "errorlist-error-close-button",
                     "onClick": [Function],
                   },
                   "ref": null,
@@ -511,12 +663,30 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "グループメンバーのカードが正しくありません。",
+                "children": Array [
+                  <span>
+                    グループメンバーのカードが正しくありません。
+                  </span>,
+                  false,
+                ],
                 "className": "message-body",
                 "data-test": "errorlist-error-body",
               },
               "ref": null,
-              "rendered": "グループメンバーのカードが正しくありません。",
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "グループメンバーのカードが正しくありません。",
+                  },
+                  "ref": null,
+                  "rendered": "グループメンバーのカードが正しくありません。",
+                  "type": "span",
+                },
+                false,
+              ],
               "type": "div",
             },
           ],

--- a/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
+++ b/src/component/__tests__/__snapshots__/ErrorList.spec.js.snap
@@ -48,14 +48,14 @@ ShallowWrapper {
               onClick={[Function]}
             />
           </div>
-          <div
+          <styled.div
             className="message-body"
           >
-            <span
+            <styled.span
               data-test="errorlist-error-body"
             >
               ログインしていません
-            </span>
+            </styled.span>
             <button
               className="button is-info"
               data-test="errorlist-error-ok-button"
@@ -63,7 +63,7 @@ ShallowWrapper {
             >
               OK
             </button>
-          </div>
+          </styled.div>
         </article>,
         <article
           className="message is-danger"
@@ -83,15 +83,15 @@ ShallowWrapper {
               onClick={[Function]}
             />
           </div>
-          <div
+          <styled.div
             className="message-body"
           >
-            <span
+            <styled.span
               data-test="errorlist-error-body"
             >
               グループメンバーのカードが正しくありません。
-            </span>
-          </div>
+            </styled.span>
+          </styled.div>
         </article>,
       ],
       "data-test": "errorlist",
@@ -118,14 +118,14 @@ ShallowWrapper {
                 onClick={[Function]}
               />
             </div>,
-            <div
+            <styled.div
               className="message-body"
             >
-              <span
+              <styled.span
                 data-test="errorlist-error-body"
               >
                 ログインしていません
-              </span>
+              </styled.span>
               <button
                 className="button is-info"
                 data-test="errorlist-error-ok-button"
@@ -133,7 +133,7 @@ ShallowWrapper {
               >
                 OK
               </button>
-            </div>,
+            </styled.div>,
           ],
           "className": "message is-info",
           "data-test": "errorlist-error",
@@ -192,14 +192,14 @@ ShallowWrapper {
           Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "host",
+            "nodeType": "class",
             "props": Object {
               "children": Array [
-                <span
+                <styled.span
                   data-test="errorlist-error-body"
                 >
                   ログインしていません
-                </span>,
+                </styled.span>,
                 <button
                   className="button is-info"
                   data-test="errorlist-error-ok-button"
@@ -215,14 +215,14 @@ ShallowWrapper {
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "class",
                 "props": Object {
                   "children": "ログインしていません",
                   "data-test": "errorlist-error-body",
                 },
                 "ref": null,
                 "rendered": "ログインしていません",
-                "type": "span",
+                "type": [Function],
               },
               Object {
                 "instance": null,
@@ -239,7 +239,7 @@ ShallowWrapper {
                 "type": "button",
               },
             ],
-            "type": "div",
+            "type": [Function],
           },
         ],
         "type": "article",
@@ -264,15 +264,15 @@ ShallowWrapper {
                 onClick={[Function]}
               />
             </div>,
-            <div
+            <styled.div
               className="message-body"
             >
-              <span
+              <styled.span
                 data-test="errorlist-error-body"
               >
                 グループメンバーのカードが正しくありません。
-              </span>
-            </div>,
+              </styled.span>
+            </styled.div>,
           ],
           "className": "message is-danger",
           "data-test": "errorlist-error",
@@ -331,14 +331,14 @@ ShallowWrapper {
           Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "host",
+            "nodeType": "class",
             "props": Object {
               "children": Array [
-                <span
+                <styled.span
                   data-test="errorlist-error-body"
                 >
                   グループメンバーのカードが正しくありません。
-                </span>,
+                </styled.span>,
                 false,
               ],
               "className": "message-body",
@@ -348,18 +348,18 @@ ShallowWrapper {
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "class",
                 "props": Object {
                   "children": "グループメンバーのカードが正しくありません。",
                   "data-test": "errorlist-error-body",
                 },
                 "ref": null,
                 "rendered": "グループメンバーのカードが正しくありません。",
-                "type": "span",
+                "type": [Function],
               },
               false,
             ],
-            "type": "div",
+            "type": [Function],
           },
         ],
         "type": "article",
@@ -392,14 +392,14 @@ ShallowWrapper {
                 onClick={[Function]}
               />
             </div>
-            <div
+            <styled.div
               className="message-body"
             >
-              <span
+              <styled.span
                 data-test="errorlist-error-body"
               >
                 ログインしていません
-              </span>
+              </styled.span>
               <button
                 className="button is-info"
                 data-test="errorlist-error-ok-button"
@@ -407,7 +407,7 @@ ShallowWrapper {
               >
                 OK
               </button>
-            </div>
+            </styled.div>
           </article>,
           <article
             className="message is-danger"
@@ -427,15 +427,15 @@ ShallowWrapper {
                 onClick={[Function]}
               />
             </div>
-            <div
+            <styled.div
               className="message-body"
             >
-              <span
+              <styled.span
                 data-test="errorlist-error-body"
               >
                 グループメンバーのカードが正しくありません。
-              </span>
-            </div>
+              </styled.span>
+            </styled.div>
           </article>,
         ],
         "data-test": "errorlist",
@@ -462,14 +462,14 @@ ShallowWrapper {
                   onClick={[Function]}
                 />
               </div>,
-              <div
+              <styled.div
                 className="message-body"
               >
-                <span
+                <styled.span
                   data-test="errorlist-error-body"
                 >
                   ログインしていません
-                </span>
+                </styled.span>
                 <button
                   className="button is-info"
                   data-test="errorlist-error-ok-button"
@@ -477,7 +477,7 @@ ShallowWrapper {
                 >
                   OK
                 </button>
-              </div>,
+              </styled.div>,
             ],
             "className": "message is-info",
             "data-test": "errorlist-error",
@@ -536,14 +536,14 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "host",
+              "nodeType": "class",
               "props": Object {
                 "children": Array [
-                  <span
+                  <styled.span
                     data-test="errorlist-error-body"
                   >
                     ログインしていません
-                  </span>,
+                  </styled.span>,
                   <button
                     className="button is-info"
                     data-test="errorlist-error-ok-button"
@@ -559,14 +559,14 @@ ShallowWrapper {
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "host",
+                  "nodeType": "class",
                   "props": Object {
                     "children": "ログインしていません",
                     "data-test": "errorlist-error-body",
                   },
                   "ref": null,
                   "rendered": "ログインしていません",
-                  "type": "span",
+                  "type": [Function],
                 },
                 Object {
                   "instance": null,
@@ -583,7 +583,7 @@ ShallowWrapper {
                   "type": "button",
                 },
               ],
-              "type": "div",
+              "type": [Function],
             },
           ],
           "type": "article",
@@ -608,15 +608,15 @@ ShallowWrapper {
                   onClick={[Function]}
                 />
               </div>,
-              <div
+              <styled.div
                 className="message-body"
               >
-                <span
+                <styled.span
                   data-test="errorlist-error-body"
                 >
                   グループメンバーのカードが正しくありません。
-                </span>
-              </div>,
+                </styled.span>
+              </styled.div>,
             ],
             "className": "message is-danger",
             "data-test": "errorlist-error",
@@ -675,14 +675,14 @@ ShallowWrapper {
             Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "host",
+              "nodeType": "class",
               "props": Object {
                 "children": Array [
-                  <span
+                  <styled.span
                     data-test="errorlist-error-body"
                   >
                     グループメンバーのカードが正しくありません。
-                  </span>,
+                  </styled.span>,
                   false,
                 ],
                 "className": "message-body",
@@ -692,18 +692,18 @@ ShallowWrapper {
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "host",
+                  "nodeType": "class",
                   "props": Object {
                     "children": "グループメンバーのカードが正しくありません。",
                     "data-test": "errorlist-error-body",
                   },
                   "ref": null,
                   "rendered": "グループメンバーのカードが正しくありません。",
-                  "type": "span",
+                  "type": [Function],
                 },
                 false,
               ],
-              "type": "div",
+              "type": [Function],
             },
           ],
           "type": "article",


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@86a4db39c5367370192a3bf8824202fe7523fa1a
 * Sakuten/backend@b6672e0459cf1e5f716bcbbfd7da29ab240b9c0c

変更内容
================

  * Fix #88
  * エラーにOKボタン
    * やることはxボタンと同じ
  * エラーに応じてエラーメッサー時ボックスの色を変える
    * `internal` → `is-danger`
    * `error` → `is-warning`
    * `notice` → `is-info`

修正前の挙動:
-------------

  * ない

修正後の挙動:
-------------

  * ある

![60cff208 ngrok io_lottery_login_staff iphone 6_7_8](https://user-images.githubusercontent.com/16184855/45493865-b8f22380-b7aa-11e8-82ae-0580fb31448d.png)


影響範囲
================

  * ない
