### PR TITLE
Fix: Use api.sakuten.jp on master branch, use heroku otherwise

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,14 @@
   publish = "build"
   command = "yarn build"
 
-[build.environment]
+[context.production]
+  REACT_APP_API_SERVER = "https://api.sakuten.jp"
+
+[context.deploy-preview.environment]
+  REACT_APP_API_SERVER = "https://sakuten-api-testflight.herokuapp.com"
+  REACT_APP_STAGING_BUILD = "1"
+
+[context.branch-deploy.environment]
   REACT_APP_API_SERVER = "https://sakuten-api-testflight.herokuapp.com"
   REACT_APP_STAGING_BUILD = "1"
 


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@f6ff0182d099848cc718cbf3f87cccf73b272e3b
 * Sakuten/backend@7cbcfb65a75f8e031a7d94d8a07e122997c55071

変更内容
================

  * Fix: Use api.sakuten.jp on master branch, use heroku otherwise

修正前の挙動:
-------------

  * いつもheroku

修正後の挙動:
-------------

  * Use api.sakuten.jp on master branch, use heroku otherwise

影響範囲
================

  * ない
