### PR TITLE
雲があっても文字か見えるようにする

### DIFF
--- a/src/cloud.svg
+++ b/src/cloud.svg
@@ -1,7 +1,7 @@
 <!--?xml version="1.0" encoding="utf-8"?-->
 <!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 
-<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" style="width: 512px; height: 512px; opacity: 1;" xml:space="preserve">
+<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" style="width: 512px; height: 512px; opacity: 1;" xml:space="preserve" fill-opacity="0.7">
 <style type="text/css">
 	.st0{fill:#4B4B4B;}
 </style>


### PR DESCRIPTION


変更内容
================

  *  issue #77 
  * 雲があっても文字か見えるようにするために、雲を透明に。

修正前の挙動:
-------------

  * 雲で文字が見えない！

修正後の挙動:
-------------

  * 雲のfill-opacityを0.7にして半透明にした

影響範囲
================

  * 特になし
