### PR TITLE
ログインに失敗したらQR読み取りに戻す

### DIFF
--- a/src/event/credential.js
+++ b/src/event/credential.js
@@ -18,7 +18,13 @@ export class CredentialObject {
   }
 
   onLogin = async () => {
-    const response = await authenicate(this.store.credential.secretId, this.store.credential.recaptchaResponse)
+    let response
+    try {
+      response = await authenicate(this.store.credential.secretId, this.store.credential.recaptchaResponse)
+    } catch (e) {
+      this.store.credential.logout()
+      throw e
+    }
     const json = response.data
     if ('token' in json) {
       this.store.credential.setToken(json.token)

--- a/src/event/credential.js
+++ b/src/event/credential.js
@@ -18,13 +18,10 @@ export class CredentialObject {
   }
 
   onLogin = async () => {
-    let response
-    try {
-      response = await authenicate(this.store.credential.secretId, this.store.credential.recaptchaResponse)
-    } catch (e) {
+    const response = await authenicate(this.store.credential.secretId, this.store.credential.recaptchaResponse).catch(e => {
       this.store.credential.logout()
-      throw e
-    }
+      return Promise.reject(e)
+    })
     const json = response.data
     if ('token' in json) {
       this.store.credential.setToken(json.token)

--- a/src/event/error.js
+++ b/src/event/error.js
@@ -20,7 +20,7 @@ export class ErrorObject {
 
   onError = (code, message) => {
     if (code === 0) {
-      this.store.credential.setToken('')
+      this.store.credential.logout()
     }
     this.store.error.addError(code, message)
   }


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@539cd6e113144f22bc27ae228f77b2bdcc83f671
 * Sakuten/backend@3bf6b46774149c750ecef67812c4fe2cb1e243ee

変更内容
================

  * ログインに失敗したらQR読み取りに戻す

修正前の挙動:
-------------

  * QRリーダーだけが消えてリロードせざるを得ない。

修正後の挙動:
-------------

  * QRリーダー、現る。

影響範囲
================

  * なさみ
