### PR TITLE
応募のユーザー入力をログイン・応募時にクリア

### DIFF
--- a/src/event/credential.js
+++ b/src/event/credential.js
@@ -25,6 +25,7 @@ export class CredentialObject {
     const json = response.data
     if ('token' in json) {
       this.store.credential.setToken(json.token)
+      this.store.application.clearInputs()
       await this.store.fetchStatus()
       if (this.store.credential.isLoggedInAsChecker) {
         this.store.router.history.push('?staff')

--- a/src/event/index.js
+++ b/src/event/index.js
@@ -39,6 +39,8 @@ export class Event {
       </div>
     )
     this.dialog.onOpen('応募しました', content, 'OK')
+
+    this.store.application.clearInputs()
     await this.store.fetchStatus()
     if (this.store.credential.isUsedByStaff) {
       this.store.credential.logout()

--- a/src/store/__tests__/application.spec.js
+++ b/src/store/__tests__/application.spec.js
@@ -24,6 +24,19 @@ describe('stores', () => {
       expect(store.groupMemberList).toEqual([['secret_id1', 'public_id1'], ['secret_id2', 'public_id2']])
     })
 
+    it('can clear user inputs', () => {
+      const initialLottery = store.lottery
+      const initialClassroom = store.classroom
+      store.setClassroom(2)
+      store.setLottery(2)
+      store.addGroupMember('secret_id1', 'public_id1')
+      store.addGroupMember('secret_id2', 'public_id2')
+      store.clearInputs()
+      expect(store.lottery).toBe(initialLottery)
+      expect(store.classroom).toBe(initialClassroom)
+      expect(store.groupMemberList).toEqual([])
+    })
+
     it('can remove a group member by id', () => {
       store.addGroupMember('secret_id1', 'public_id1')
       store.addGroupMember('secret_id2', 'public_id2')

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -15,6 +15,12 @@ export class ApplicationObject {
     return this.groupMemberList.length < 3
   }
 
+  @action.bound clearInputs () {
+    this.classroom = 1
+    this.lottery = 1
+    this.groupMemberList = []
+  }
+
   @action.bound setClassroom (classroomId) {
     this.classroom = classroomId
   }


### PR DESCRIPTION
 * Linux coordiserver 4.17.0-3-amd64#1 SMP Debian 4.17.17-1 (2018-08-18) x86_64 GNU/Linux
 * Sakuten/devenv@22a22738848c07dcea5edb0fdfd1e0b026b84e21
 * Sakuten/frontend@0db951da11b8e5debd55ea80693c390db2201b1d
 * Sakuten/backend@e1e1da0e8f9c58d8870d791ddcfe48f9cb285564

変更内容
================

  * 応募のユーザー入力をログイン・応募時にクリア
  * Fix #121

修正前の挙動:
-------------

  * GroupMemberが残る。やめれ

修正後の挙動:
-------------

  * 残らない(GroupMemberに限らずClassroomも)

影響範囲
================

  * NASA