### PR TITLE
キャンセル待ち対応

### DIFF
--- a/src/component/StatusTag.js
+++ b/src/component/StatusTag.js
@@ -5,7 +5,8 @@ const StatusTag = ({status, className, left}) => {
   const tags = {
     'pending': ['is-dark', '発表をお待ちください。'],
     'won': ['is-success', '当選しました。'],
-    'lose': ['is-danger', '落選しました。']
+    'lose': ['is-danger', '落選しました。'],
+    'waiting': ['is-warning', 'キャンセル待ちです。']
   }
 
   const tagInfo = tags[status] || ['', status]


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->

変更内容
================

  * statusがwaitingの時に、`キャンセル待ちです。`と表示されます。
  * #150 

修正前の挙動:
-------------

  * waitingになっても。キャンセル待ちとは教示されないです。

修正後の挙動:
-------------

  * 　黄色のタグでキャンセル待ちと表示されます。

影響範囲
================

  *　おそらくなしです。

