### PR TITLE
キャンセルボタンがない時には、`団体応募の代表者キャンセルで、メンバー全員まとめてキャンセル`を表示させない

### DIFF
--- a/src/component/ApplicationList.js
+++ b/src/component/ApplicationList.js
@@ -31,7 +31,9 @@ const ApplicationList = ({list, onCancel}) => (
                 {c.status === 'pending' && <p>抽選結果発表: <b>{c.lottery.end_of_drawing}</b></p>}
                 {c.is_rep && <p>団体応募代表者です</p>}
                 {c.is_member && <p>団体応募のメンバーです</p>}
-                {c.group_members.length !== 0 && <div><p>一緒に応募した人: <b>{c.group_members.map(m => m.public_id).join(', ')}</b></p><RedText>団体応募代表者がキャンセルすると、メンバー全員の応募がキャンセルされます。</RedText></div>}
+                {c.group_members.length !== 0 && <div><p>一緒に応募した人: <b>{c.group_members.map(m => m.public_id).join(', ')}</b></p>
+                  {c.status === 'pending' && <RedText>団体応募代表者がキャンセルすると、メンバー全員の応募がキャンセルされます。</RedText> }
+                </div>}
               </div>
             </div>
             {c.status === 'pending' && <footer className='card-footer'>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- ./scripts/report.sh で生成できます -->
 * Darwin haruka.local 17.5.0 Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64 x86_64
 * Sakuten/devenv@bd8de28a0e5c44fa1c35890b3741cdee308475cf
 * Sakuten/frontend@0f73c14406432356726d0c9891b40373e3939b45
 * Sakuten/backend@6ea09eb8b1e95e0306718fc5b509c326c8ae3b02

変更内容
================

  * キャンセルボタンがない時には、`団体応募の代表者キャンセルで、メンバー全員まとめてキャンセル`を表示させない
  * #118 

修正前の挙動:
-------------

  * キャンセルボタンがない時には、`団体応募の代表者キャンセルで、メンバー全員まとめてキャンセル`が表示されてしまった

修正後の挙動:
-------------

  * キャンセルボタンがない時には、`団体応募の代表者キャンセルで、メンバー全員まとめてキャンセル`が表示されてない。

影響範囲
================

  *　おそらくない