### PR TITLE
5A問題を撲滅

### DIFF
--- a/src/component/LotteryListIsEmptyContent.js
+++ b/src/component/LotteryListIsEmptyContent.js
@@ -7,7 +7,7 @@ const LotteryListIsEmptyContent = () => {
         応募できる抽選がありません
       </p>
       <p>
-        応募受付時間になったら、下のボタンを押して再読み込みしてください
+        応募受付時間になりましたら、下のボタンを押して再読み込みしてください
       </p>
       <button onClick={() => window.location.reload()}className='button is-info'>再読み読み</button>
     </div>

--- a/src/component/LotteryListIsEmptyContent.js
+++ b/src/component/LotteryListIsEmptyContent.js
@@ -4,7 +4,10 @@ const LotteryListIsEmptyContent = () => {
   return (
     <div>
       <p>
-        応募できる抽選がありません。応募受付時間でならば、下のボタンを押して再読み込みしてください
+        応募できる抽選がありません
+      </p>
+      <p>
+        応募受付時間になったら、下のボタンを押して再読み込みしてください
       </p>
       <button onClick={() => window.location.reload()}className='button is-info'>再読み読み</button>
     </div>

--- a/src/component/LotteryListIsEmptyContent.js
+++ b/src/component/LotteryListIsEmptyContent.js
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const LotteryListIsEmptyContent = () => {
+  return (
+    <div>
+      <p>
+        応募できる抽選がありません。応募受付時間でならば、下のボタンを押して再読み込みしてください
+      </p>
+      <button onClick={() => window.location.reload()}className='button is-info'>再読み読み</button>
+    </div>
+  )
+}
+
+export default LotteryListIsEmptyContent

--- a/src/event/index.js
+++ b/src/event/index.js
@@ -24,6 +24,10 @@ export class Event {
 
   onApplyLottery = async () => {
     this.dialog.onOpen('応募しています', 'しばらくお待ちください', 'お待ちください', false)
+    if (this.store.application.lotteryList.length === 0) {
+      this.dialog.onOpen('失敗しました', '応募できる抽選がありません。再読み込みしてください', '戻る')
+      return
+    }
     if (this.store.application.classroom === 0 | this.store.application.classroom === '0') {
       this.dialog.onOpen('失敗しました', 'クラスが選択されていません', '戻る')
       return

--- a/src/event/index.js
+++ b/src/event/index.js
@@ -8,6 +8,7 @@ import {DialogObject} from './dialog'
 
 import {applyLottery, cancelLottery} from '../api/operation'
 
+import LotteryListIsEmptyContent from '../component/LotteryListIsEmptyContent'
 export class Event {
   constructor (store) {
     this.store = store
@@ -25,9 +26,10 @@ export class Event {
   onApplyLottery = async () => {
     this.dialog.onOpen('応募しています', 'しばらくお待ちください', 'お待ちください', false)
     if (this.store.application.lotteryList.length === 0) {
-      this.dialog.onOpen('失敗しました', '応募できる抽選がありません。再読み込みしてください', '戻る')
+      this.dialog.onOpen('失敗しました', <LotteryListIsEmptyContent />, '戻る')
       return
     }
+
     if (this.store.application.classroom === 0 | this.store.application.classroom === '0') {
       this.dialog.onOpen('失敗しました', 'クラスが選択されていません', '戻る')
       return


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

変更内容
================

  * 5A問題を撲滅します。
  * #170 

修正前の挙動:
-------------

  * 違うクラスを選択したのに、5Aになる。

修正後の挙動:
-------------

  * 違うクラスを選択したのに、5Aになることはない。

## どうやって解決したか

応募可能時間より前からログインして再読みこみをしてないせいで、
応募可能なロッテリーを取得していないため、デフォルト値の5Aに応募されてしまう。
なので、応募可能なロッテリーが取得されてなかったら、それを伝え、再読み込みボタンを押してもらい、取得してもらう

<img width="679" alt="スクリーンショット 2019-09-05 22 59 21" src="https://user-images.githubusercontent.com/26423094/64354865-2e4da880-d03b-11e9-9cc5-c52e1c7411ab.png">

