### PR TITLE
resolve #169 LotteryViewコンポーネントがrender内でonChangeを呼ばないようにするFix

### DIFF
--- a/src/component/LotteryView.js
+++ b/src/component/LotteryView.js
@@ -6,12 +6,18 @@ const LotteryView = ({list, classroom, onChange}) => (
     {
       list.length !== 0 ? list
         .filter(c => c.classroom_id === Number(classroom))
-        .map(c => {
-          onChange(c.id)
-          return <span data-test='lottery-lottery' key={c.id} value={c.id}>第{c.index + 2}公演</span>
-        }) : <span data-test='lottery-notfound'>現在応募は受け付けておりません。</span>
+        .map(c => <PerformanceNumber onChange={onChange} c={c} />) : <span data-test='lottery-notfound'>現在応募は受け付けておりません。</span>
     }
   </div>
 )
 
+class PerformanceNumber extends React.Component {
+  componentWillMount () {
+    this.props.onChange(this.props.c.id)
+  }
+  render () {
+    const { c } = this.props
+    return <span data-test='lottery-lottery' key={c.id} value={c.id}>第{c.index + 2}公演</span>
+  }
+}
 export default observer(LotteryView)


### PR DESCRIPTION


変更内容
================

  *  LotteryViewコンポーネントがrender内でonChangeを呼んでおり、Waringが出ていた
  * #169 

修正前の挙動:
-------------

  * クラスを選ぶと、LotteryViewが表示される。その時に、 #169　のようなWarningが出ていた。

修正後の挙動:
-------------

  * クラスを選ぶと、LotteryViewが表示される。その時に、 Warningは表示されない
  *  onChangeはcomponentDidMountで呼ぶのが正しいのでそうしてる。

